### PR TITLE
Rest 2319 cachear el listado de bancos pse desde el backend

### DIFF
--- a/src/PSEIntegration.php
+++ b/src/PSEIntegration.php
@@ -72,6 +72,10 @@ class PSEIntegration
         return $this->services->getBankList($request);
     }
 
+    public function deleteRedisSdkCache(){ 
+        return $this->services->deleteRedisSdkCache();
+    }
+
     /**
      * Create a simple transaction payment
      * @throws JsonMapper_Exception

--- a/src/Services/ApigeeServices.php
+++ b/src/Services/ApigeeServices.php
@@ -51,7 +51,7 @@ class ApigeeServices
     private RedisCache $redisCache;
 
     private const APIGEE_TOKEN_TTL = 3000;
-    private const APIGEE_BANK_LIST_TTL = 60;
+    private const APIGEE_BANK_LIST_TTL = 1440;
 
     /**
      * Default constructor for Apigee service

--- a/src/Services/ApigeeServices.php
+++ b/src/Services/ApigeeServices.php
@@ -51,7 +51,7 @@ class ApigeeServices
     private RedisCache $redisCache;
 
     private const APIGEE_TOKEN_TTL = 3000;
-    private const APIGEE_BANK_LIST_TTL = 1440;
+    private const APIGEE_BANK_LIST_TTL = 86400; // seconds
 
     /**
      * Default constructor for Apigee service

--- a/src/Services/ApigeeServices.php
+++ b/src/Services/ApigeeServices.php
@@ -215,6 +215,17 @@ class ApigeeServices
         }
     }
 
+    // Reset Redis SDk cache
+    public function deleteRedisSdkCache(){
+        $key = 'apigee-bank-list-' . $this->domainFromUrl;
+        $this->redisCache->delete($key);
+        $testDelete = $this->redisCache->get($key);
+        if (is_null($testDelete)) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Get bank list
      * @throws JsonMapper_Exception|GuzzleException

--- a/src/Services/ApigeeServices.php
+++ b/src/Services/ApigeeServices.php
@@ -7,6 +7,7 @@ use ArrayObject;
 use Exception;
 use JsonMapper;
 use JsonMapper_Exception;
+use Illuminate\Support\Facades\Log;
 use GuzzleHttp\Exception\GuzzleException;
 use PSEIntegration\Cache\RedisCache;
 use PSEIntegration\Models\GetBankListRequest;
@@ -236,10 +237,21 @@ class ApigeeServices
         $key = 'apigee-bank-list-' . $this->domainFromUrl;
         $apigeeBankList = $this->redisCache->get($key);
         if ($apigeeBankList) {
+            Log::info('banklist_skd_ach_pse', [
+                'key' => $key,
+                'from' => 'Redis',
+                'value' => $apigeeBankList
+            ]);
             return $apigeeBankList;
         }
 
         $bankList = $this->sendRequest("GetBankListNF", $request, "\PSEIntegration\Models\Bank");
+
+        Log::info('banklist_skd_ach_pse', [
+            'key' => $key,
+            'from' => 'PSE',
+            'value' => $bankList
+        ]);
 
         $this->redisCache->set(
             $key,


### PR DESCRIPTION
Células:
Nombre Célula Pagos
Desarrolladores:
Nombre Jorge Lacruz.
Tarjetas: https://epayco.atlassian.net/browse/REST-2319
Funcionalidades:
Se modifica el ttl de Redis en el sdk de ACH para que el listado de bancos dure en cache 24 horas asi como tambien se expone un servicio para hacer el reset manual de dicho cache en el momento que sea requerido.